### PR TITLE
update model name

### DIFF
--- a/tuning/Fine-tuning.md
+++ b/tuning/Fine-tuning.md
@@ -16,7 +16,7 @@ dataset = load_dataset("lucasmccabe-lmi/CodeAlpaca-20k", split="train")
 
 # We load the model and the tokenizer
 # TODO: change path to bamba model when uploaded
-model_path = "/ibm-llm-input/flim/Avengers-Jamba-9B-HF"
+model_path = "ibm-fms/Bamba-9B"
 model = AutoModelForCausalLM.from_pretrained(model_path)
 tokenizer = AutoTokenizer.from_pretrained(model_path)
 
@@ -87,8 +87,6 @@ trainer = SFTTrainer(
     args=train_args, 
     formatting_func=formatting_prompts_func,
     data_collator=collator,
-    max_seq_length=4096,
-    
 )
 # Start the training
 trainer.train()
@@ -116,7 +114,6 @@ trainer = SFTTrainer(
     peft_config=peft_config,
     formatting_func=formatting_prompts_func,
     data_collator=collator,
-    max_seq_length=4096
 )
 
 trainer.train()


### PR DESCRIPTION
The PR updates model name to the one from HF 

`max_seq_length` was also being used in the wrong placed , and now it is removed and script is correct
